### PR TITLE
Update zwabo-mirrorz_dsp.ttl

### DIFF
--- a/custom-ttl/zwabo-mirrorz/zwabo-mirrorz_dsp.ttl
+++ b/custom-ttl/zwabo-mirrorz/zwabo-mirrorz_dsp.ttl
@@ -61,7 +61,7 @@
     ] ;
 
     lv2:port [
-        a lv2:InputPort, lv2:ControlPort ;
+        a lv2:OutputPort, lv2:ControlPort ;
         lv2:index 4 ;
         lv2:name "BILL" ;
         lv2:symbol "BILL" ;
@@ -70,7 +70,7 @@
         lv2:maximum 1 ;
     ] ,
     [
-        a lv2:InputPort, lv2:ControlPort ;
+        a lv2:OutputPort, lv2:ControlPort ;
         lv2:index 5 ;
         lv2:name "BOUL" ;
         lv2:symbol "BOUL" ;


### PR DESCRIPTION
Changed line 64 & 73  InputPort to OutputPort , to remove "Bill* and "Boul" knobs on the GUI